### PR TITLE
feat: add empty checking to filter out empty weekly news md file

### DIFF
--- a/data/2024/week10.md
+++ b/data/2024/week10.md
@@ -1,5 +1,6 @@
 ---
 curator: Coinmandeer
+skip: true
 ---
 
 <!--
@@ -18,20 +19,20 @@ curator: Coinmandeer
 ### Other
 -->
 
-
 ---
 
 ### Upcoming events
-*(new/changes in **bold**)*
 
-* Apr 10, [zkSummit](https://www.zksummit.com/) (Athens) conference
-* Apr 12-14, [ETHDam](https://www.ethdam.com/) hackathon
-* **Apr 24, [Privacy Reunion 2](https://twitter.com/privacyguardia/status/1762532962875121786) (Barcelona) conference**
-* May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
-* May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
-* Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
-* Jun 19-26, [Web3Privacy Now Hackathon](https://web3privacy.info/events/) (Bled)
-* Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
-* Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
-* Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
-* Oct, [ETHBrno](https://ethbrno.cz/) hackathon
+_(new/changes in **bold**)_
+
+- Apr 10, [zkSummit](https://www.zksummit.com/) (Athens) conference
+- Apr 12-14, [ETHDam](https://www.ethdam.com/) hackathon
+- **Apr 24, [Privacy Reunion 2](https://twitter.com/privacyguardia/status/1762532962875121786) (Barcelona) conference**
+- May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
+- May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
+- Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
+- Jun 19-26, [Web3Privacy Now Hackathon](https://web3privacy.info/events/) (Bled)
+- Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
+- Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
+- Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
+- Oct, [ETHBrno](https://ethbrno.cz/) hackathon

--- a/data/2024/week13.md
+++ b/data/2024/week13.md
@@ -1,5 +1,6 @@
 ---
 curator: mykola
+skip: true
 ---
 
 <!--
@@ -17,5 +18,3 @@ curator: mykola
 
 ### Other
 -->
-
-

--- a/data/2024/week15.md
+++ b/data/2024/week15.md
@@ -1,5 +1,6 @@
 ---
 curator: mykola
+skip: true
 ---
 
 <!--
@@ -17,5 +18,3 @@ curator: mykola
 
 ### Other
 -->
-
-

--- a/data/2024/week16.md
+++ b/data/2024/week16.md
@@ -1,5 +1,6 @@
 ---
 curator: mykola
+skip: true
 ---
 
 <!--

--- a/data/2024/week17.md
+++ b/data/2024/week17.md
@@ -1,5 +1,6 @@
 ---
 curator: mykola
+skip: true
 ---
 
 <!--

--- a/data/2024/week20.md
+++ b/data/2024/week20.md
@@ -1,5 +1,6 @@
 ---
 curator: radek
+skip: true
 ---
 
 <!--
@@ -25,7 +26,7 @@ curator: radek
 ---
 
 ### Releases
-  
+
 ---
 
 ### Ecosystem
@@ -37,7 +38,7 @@ curator: radek
 ---
 
 ### Governments
-  
+
 ---
 
 ### Other
@@ -45,14 +46,15 @@ curator: radek
 ---
 
 ### Upcoming events
-*(new/changes in **bold**)*
 
-* May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
-* May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
-* Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
-* Jun 27, [Privacy Reunion #3](https://lu.ma/privacyreunion3) (Neuchâtel)
-* **Jul 12, [Web3Privacy Now "Occupy meetup"](https://lu.ma/w3pn-meetup-bru1)**
-* Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
-* Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
-* Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
-* Oct, [ETHBrno](https://ethbrno.cz/) privacy hackathon
+_(new/changes in **bold**)_
+
+- May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
+- May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
+- Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
+- Jun 27, [Privacy Reunion #3](https://lu.ma/privacyreunion3) (Neuchâtel)
+- **Jul 12, [Web3Privacy Now "Occupy meetup"](https://lu.ma/w3pn-meetup-bru1)**
+- Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
+- Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
+- Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
+- Oct, [ETHBrno](https://ethbrno.cz/) privacy hackathon

--- a/data/2024/week21.md
+++ b/data/2024/week21.md
@@ -1,5 +1,6 @@
 ---
 curator: radek
+skip: true
 ---
 
 <!--
@@ -25,7 +26,7 @@ curator: radek
 ---
 
 ### Releases
-  
+
 ---
 
 ### Ecosystem
@@ -37,7 +38,7 @@ curator: radek
 ---
 
 ### Governments
-  
+
 ---
 
 ### Other
@@ -45,14 +46,15 @@ curator: radek
 ---
 
 ### Upcoming events
-*(new/changes in **bold**)*
 
-* May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
-* May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
-* Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
-* Jun 27, [Privacy Reunion #3](https://lu.ma/privacyreunion3) (Neuchâtel)
-* **Jul 12, [Web3Privacy Now "Occupy meetup"](https://lu.ma/w3pn-meetup-bru1)**
-* Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
-* Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
-* Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
-* Oct, [ETHBrno](https://ethbrno.cz/) privacy hackathon
+_(new/changes in **bold**)_
+
+- May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
+- May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
+- Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
+- Jun 27, [Privacy Reunion #3](https://lu.ma/privacyreunion3) (Neuchâtel)
+- **Jul 12, [Web3Privacy Now "Occupy meetup"](https://lu.ma/w3pn-meetup-bru1)**
+- Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
+- Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
+- Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
+- Oct, [ETHBrno](https://ethbrno.cz/) privacy hackathon

--- a/data/2024/week22.md
+++ b/data/2024/week22.md
@@ -1,5 +1,6 @@
 ---
 curator: radek
+skip: true
 ---
 
 <!--
@@ -25,7 +26,7 @@ curator: radek
 ---
 
 ### Releases
-  
+
 ---
 
 ### Ecosystem
@@ -37,7 +38,7 @@ curator: radek
 ---
 
 ### Governments
-  
+
 ---
 
 ### Other
@@ -45,14 +46,15 @@ curator: radek
 ---
 
 ### Upcoming events
-*(new/changes in **bold**)*
 
-* May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
-* May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
-* Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
-* Jun 27, [Privacy Reunion #3](https://lu.ma/privacyreunion3) (Neuchâtel)
-* **Jul 12, [Web3Privacy Now "Occupy meetup"](https://lu.ma/w3pn-meetup-bru1)**
-* Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
-* Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
-* Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
-* Oct, [ETHBrno](https://ethbrno.cz/) privacy hackathon
+_(new/changes in **bold**)_
+
+- May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
+- May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
+- Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
+- Jun 27, [Privacy Reunion #3](https://lu.ma/privacyreunion3) (Neuchâtel)
+- **Jul 12, [Web3Privacy Now "Occupy meetup"](https://lu.ma/w3pn-meetup-bru1)**
+- Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
+- Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
+- Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
+- Oct, [ETHBrno](https://ethbrno.cz/) privacy hackathon

--- a/data/2024/week23.md
+++ b/data/2024/week23.md
@@ -1,5 +1,6 @@
 ---
 curator: radek
+skip: true
 ---
 
 <!--
@@ -25,7 +26,7 @@ curator: radek
 ---
 
 ### Releases
-  
+
 ---
 
 ### Ecosystem
@@ -37,7 +38,7 @@ curator: radek
 ---
 
 ### Governments
-  
+
 ---
 
 ### Other
@@ -45,14 +46,15 @@ curator: radek
 ---
 
 ### Upcoming events
-*(new/changes in **bold**)*
 
-* May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
-* May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
-* Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
-* Jun 27, [Privacy Reunion #3](https://lu.ma/privacyreunion3) (Neuchâtel)
-* **Jul 12, [Web3Privacy Now "Occupy meetup"](https://lu.ma/w3pn-meetup-bru1)**
-* Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
-* Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
-* Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
-* Oct, [ETHBrno](https://ethbrno.cz/) privacy hackathon
+_(new/changes in **bold**)_
+
+- May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
+- May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
+- Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
+- Jun 27, [Privacy Reunion #3](https://lu.ma/privacyreunion3) (Neuchâtel)
+- **Jul 12, [Web3Privacy Now "Occupy meetup"](https://lu.ma/w3pn-meetup-bru1)**
+- Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
+- Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
+- Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
+- Oct, [ETHBrno](https://ethbrno.cz/) privacy hackathon

--- a/data/2024/week24.md
+++ b/data/2024/week24.md
@@ -1,5 +1,6 @@
 ---
 curator: radek
+skip: true
 ---
 
 <!--
@@ -25,7 +26,7 @@ curator: radek
 ---
 
 ### Releases
-  
+
 ---
 
 ### Ecosystem
@@ -37,7 +38,7 @@ curator: radek
 ---
 
 ### Governments
-  
+
 ---
 
 ### Other
@@ -45,14 +46,15 @@ curator: radek
 ---
 
 ### Upcoming events
-*(new/changes in **bold**)*
 
-* May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
-* May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
-* Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
-* Jun 27, [Privacy Reunion #3](https://lu.ma/privacyreunion3) (Neuchâtel)
-* **Jul 12, [Web3Privacy Now "Occupy meetup"](https://lu.ma/w3pn-meetup-bru1)**
-* Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
-* Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
-* Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
-* Oct, [ETHBrno](https://ethbrno.cz/) privacy hackathon
+_(new/changes in **bold**)_
+
+- May 24-26, [ETHBerlin](https://ethberlin.org/) hackathon
+- May 30, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Prague) conference
+- Jun 7-9, [MoneroKon](https://monerokon.org/) (Prague) conference & hackathon
+- Jun 27, [Privacy Reunion #3](https://lu.ma/privacyreunion3) (Neuchâtel)
+- **Jul 12, [Web3Privacy Now "Occupy meetup"](https://lu.ma/w3pn-meetup-bru1)**
+- Oct 4-6, [Hackers Congress Paralelní Polis (HCPP)](https://hcpp.cz/) (Prague) conference
+- Oct 4-6, [ETHRome](https://ethrome.org/) hackathon
+- Oct, [Web3Privacy Now Summit](https://web3privacy.info/events/) (Brno) conference
+- Oct, [ETHBrno](https://ethbrno.cz/) privacy hackathon

--- a/web/src/components/WeekNews.astro
+++ b/web/src/components/WeekNews.astro
@@ -2,6 +2,7 @@
 import { setWeek, nextMonday, format, addDays } from 'date-fns';
 const { issue, isFull } = Astro.props;
 import config from '../config.yaml';
+// import { Debug } from 'astro:components';
 
 const [ year, week ] = issue.week.split('-');
 const current = false;
@@ -12,9 +13,8 @@ function capitalizeFirstLetter(string) {
 
 ---
 
-
 <div class=`mb-8 border border-white/20`>
-    
+    <!-- <Debug answer={issue} /> -->
     <div class=`sm:flex w-full p-4 sm:p-6 bg-white/10`>
         <div class="grid gap-2 sm:gap-6 sm:flex items-center">
             <h1 class="text-2xl"><a href=`/${issue.week}`>Week {issue.week.split('-').reverse().join('/')}</a></h1>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,13 +1,15 @@
 ---
-
-import BaseLayout from '../layouts/base.astro';
-import WeekNews from '../components/WeekNews.astro';
-import issues from '../issues.json';
-
+import BaseLayout from "../layouts/base.astro";
+import WeekNews from "../components/WeekNews.astro";
+import issues from "../issues.json";
 ---
 
 <BaseLayout>
-	{issues.sort((x, y) => x.period[0] < y.period[0] ? 1 : -1).filter(i => i.newsHtml !== "").map((issue) => (
-		<WeekNews {issue} />
-	))}
+  {
+    issues
+      .sort((x, y) => (x.period[0] < y.period[0] ? 1 : -1))
+      // use skip flag to filter out any editions that should be skipped instead of relying on regex match on empty content
+      .filter((i) => i.newsHtml !== "" && !i.skip)
+      .map((issue) => <WeekNews {issue} />)
+  }
 </BaseLayout>


### PR DESCRIPTION
As mentioned this PR is to add an empty checking to the issue data filtering, by adding a new flag "skip: true" to to the file attributes for `weekX.md` that is empty and shouldn't be displayed on the site.

I think this is a more efficient way to avoid migrating old news md to a whole new format, and keep the empty old news md for housekeeping, also to avoid relying on regex match on empty content as this could be tedious for future maintenance and cause tech debt.